### PR TITLE
Feature: Ignore list

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,14 @@ jobs:
           repository: myorg/myimage
           tag: ${{ steps.docker-build.outputs.tag }}
           # fail_threshold: medium
+          # ignore_list: |
+          #   CVE-2020-1234
+          #   CVE-2020-5678
       # Access scan results in later steps
       - run: echo "${{ steps.docker-scan.outputs.total }} total vulnerabilities."
 ```
+
+>:warning: **Note**: The `ignore_list` can either be a multi-line string (like the example) or a comma-separated list of CVE IDs.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Scan an image uploaded to ECR and fail if vulnerabilities are found.
 | repository | :white_check_mark:  | ECR repository, eg myorg/myimage |
 | tag    | :white_check_mark: | Image tag to scan |
 | fail_threshold | | Fail if any vulnerabilities equal to or over this severity level are detected. Valid values: critical, high, medium, low, informational. Default value is high. |
-| ignore_list | | List of CVE IDs to ignore. |
+| ignore_list | | List of CVE IDs to ignore.<br/>:warning: **Note**: The `ignore_list` can either be a multi-line string (like the example below) or a list (separated using commas or spaces) containing CVE IDs to be ignored. |
 
 ## Outputs
 
@@ -93,8 +93,6 @@ jobs:
       # Access scan results in later steps
       - run: echo "${{ steps.docker-scan.outputs.total }} total vulnerabilities."
 ```
-
->:warning: **Note**: The `ignore_list` can either be a multi-line string (like the example) or a comma-separated list of CVE IDs.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Scan an image uploaded to ECR and fail if vulnerabilities are found.
 | repository | :white_check_mark:  | ECR repository, eg myorg/myimage |
 | tag    | :white_check_mark: | Image tag to scan |
 | fail_threshold | | Fail if any vulnerabilities equal to or over this severity level are detected. Valid values: critical, high, medium, low, informational. Default value is high. |
+| ignore_list | | List of CVE IDs to ignore. |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,8 @@ inputs:
     description: >
       Fail if any vulnerabilities equal to or over this severity level are detected. Valid values: critical, high, medium, low, informational.
     default: medium
+  ignore_list:
+    description: List of CVE IDs to ignore in the vulnerability findings.
 outputs:
   critical:
     description: Number of critical vulnerabilities detected.

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ const countIgnoredFindings = (ignoredFindings) =>
 
 /**
  * Returns display text for a severity level.
- * @param {string} severity
+ * @param {keyof IgnoredCounts} severity
  * @param {IgnoredCounts} counts
  * @returns {string}
  */
@@ -168,7 +168,7 @@ const main = async () => {
   console.log(`${medium.toString().padStart(3, ' ')} Medium ${getCount('medium', ignoredCounts)}`)
   console.log(`${low.toString().padStart(3, ' ')} Low ${getCount('low', ignoredCounts)}`)
   console.log(`${informational.toString().padStart(3, ' ')} Informational ${getCount('informational', ignoredCounts)}`)
-  console.log(`${indeterminate.toString().padStart(3, ' ')} Undefined`)
+  console.log(`${indeterminate.toString().padStart(3, ' ')} Undefined ${getCount('undefined', ignoredCounts)}`)
   console.log('=================')
   console.log(`${total.toString().padStart(3, ' ')} Total ${getCount('total', ignoredCounts)}`)
 

--- a/index.js
+++ b/index.js
@@ -203,7 +203,7 @@ const main = async () => {
   const low = counts.LOW || 0
   const informational = counts.INFORMATIONAL || 0
   const indeterminate = counts.UNDEFINED || 0
-  const ignored = ignoreList.length
+  const ignored = ignoredFindings.length
   const total = critical + high + medium + low + informational + indeterminate
   core.setOutput('critical', critical.toString())
   core.setOutput('high', high.toString())

--- a/index.js
+++ b/index.js
@@ -44,7 +44,8 @@ const countIgnoredFindings = (ignoredFindings) =>
   ignoredFindings.reduce(
     (counts, finding) => {
       const updatedCount = { ...counts }
-      updatedCount[finding.severity] = counts[finding.severity] + 1
+      const severity = finding.severity.toLowerCase()
+      updatedCount[severity] = counts[severity] + 1
       updatedCount.total++
       return updatedCount
     },
@@ -157,21 +158,21 @@ const main = async () => {
   core.setOutput('ignored', ignored.toString())
   core.setOutput('total', total.toString())
   console.log('Vulnerabilities found:')
-  console.log(`${critical.toString().padStart(3, ' ')} Critical ${getCount(  'CRITICAL',  ignoredCounts)}`)
-  console.log(`${high.toString().padStart(3, ' ')} High ${getCount(  'HIGH',  ignoredCounts)}`)
-  console.log(`${medium.toString().padStart(3, ' ')} Medium ${getCount(  'MEDIUM',  ignoredCounts)}`)
-  console.log(`${low.toString().padStart(3, ' ')} Low ${getCount('LOW', ignoredCounts)}`)
-  console.log(`${informational.toString().padStart(3, ' ')} Informational ${getCount(  'INFORMATIONAL',  ignoredCounts)}`)
+  console.log(`${critical.toString().padStart(3, ' ')} Critical ${getCount('critical', ignoredCounts)}`)
+  console.log(`${high.toString().padStart(3, ' ')} High ${getCount('high', ignoredCounts)}`)
+  console.log(`${medium.toString().padStart(3, ' ')} Medium ${getCount('medium', ignoredCounts)}`)
+  console.log(`${low.toString().padStart(3, ' ')} Low ${getCount('low', ignoredCounts)}`)
+  console.log(`${informational.toString().padStart(3, ' ')} Informational ${getCount('informational', ignoredCounts)}`)
   console.log(`${indeterminate.toString().padStart(3, ' ')} Undefined`)
   console.log('=================')
-  console.log(`${total.toString().padStart(3, ' ')} Total ${getCount(  'TOTAL',  ignoredCounts)}`)
+  console.log(`${total.toString().padStart(3, ' ')} Total ${getCount('total', ignoredCounts)}`)
 
   const numFailingVulns =
-    failThreshold === 'informational' ? total - ignoredCounts.INFORMATIONAL
-      : failThreshold === 'low' ? critical + high + medium + low - ignoredCounts.LOW
-        : failThreshold === 'medium' ? critical + high + medium - ignoredCounts.MEDIUM
-          : failThreshold === 'high' ? critical + high - ignoredCounts.HIGH
-            : /* failThreshold === 'critical' ? */ critical - ignoredCounts.CRITICAL
+    failThreshold === 'informational' ? total - ignoredCounts.informational
+      : failThreshold === 'low' ? critical + high + medium + low - ignoredCounts.low
+        : failThreshold === 'medium' ? critical + high + medium - ignoredCounts.medium
+          : failThreshold === 'high' ? critical + high - ignoredCounts.high
+            : /* failThreshold === 'critical' ? */ critical - ignoredCounts.critical
 
   if (numFailingVulns > 0) {
     throw new Error(`Detected ${numFailingVulns} vulnerabilities with severity >= ${failThreshold} (the currently configured fail_threshold).`)

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ const main = async () => {
   }
 
   // Sanity check
-  if (status != 'COMPLETE') {
+  if (status !== 'COMPLETE') {
     throw new Error(`Unhandled scan status "${status}". API response: ${JSON.stringify(findings)}`)
   }
 
@@ -107,10 +107,10 @@ const main = async () => {
   }
 }
 
-(async function () {
+;(async function () {
   try {
     await main()
   } catch (error) {
     core.setFailed(error.message)
   }
-}())
+})()

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ const getCount = (severity, counts) =>
 
 /**
  * Build an array with CVE IDs to ignore in the counts.
- * @param {string | string[]} list - Comma-separated list, string with newlines or array of CVE IDs.
+ * @param {string | string[]} list - Comma/space/newline-separated list or array of CVE IDs.
  * @returns {string[]} Array of CVE IDs
  */
 const parseIgnoreList = (list) => {
@@ -71,7 +71,7 @@ const parseIgnoreList = (list) => {
   const ignoreList =
     list
       .trim() // remove trailing newlines if any
-      .replace(/\n/g, ',') // replace newlines with commas, if any
+      .replace(/\n|\s/g, ',') // replace newlines or spaces with commas, if any
       .split(',') // build the array
       .map((i) => i.trim()) // ensure each item doesn't contain any white-space
       .filter(Boolean) // remove empty items

--- a/index.js
+++ b/index.js
@@ -141,6 +141,9 @@ const main = async () => {
   const ignoredFindings = findingsList.filter(({ name }) => ignoreList.includes(name))
 
   if (ignoreList.length !== ignoredFindings.length) {
+    const missedIgnores = ignoreList.filter(name => !ignoredFindings.map(d => d.name).includes(name))
+    console.log('The following CVEs were not found in the result set:')
+    missedIgnores.forEach(miss => console.log(`  - ${miss}`))
     throw new Error(`Ignore list contains CVE IDs that were not returned in the findings result set. They may be invalid or no longer be current vulnerabilities.`)
   }
 

--- a/index.js
+++ b/index.js
@@ -14,6 +14,13 @@ const AWS = require('aws-sdk')
  * @typedef {{ severity: string }} ImageScanFinding https://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_ImageScanFinding.html
  */
 
+/**
+ * @param {AWS.ECR} ECR
+ * @param {string} repository
+ * @param {string} tag
+ * @param {boolean} useMaxResults
+ * @returns {AWS.Request|AWS.AWSError|null} Results, Error or `null`.
+ */
 const getFindings = async (ECR, repository, tag, useMaxResults = false) => {
   return ECR.describeImageScanFindings({
     imageId: {

--- a/index.js
+++ b/index.js
@@ -189,9 +189,9 @@ const main = async () => {
   const ignoredFindings = findingsList.filter(({ name }) => ignoreList.includes(name))
 
   if (ignoreList.length !== ignoredFindings.length) {
-    const missedIgnores = ignoreList.filter(name => !ignoredFindings.map(d => d.name).includes(name))
+    const missedIgnores = ignoreList.filter(name => !ignoredFindings.map(({ name }) => name).includes(name))
     console.log('The following CVEs were not found in the result set:')
-    missedIgnores.forEach(miss => console.log(`  - ${miss}`))
+    missedIgnores.forEach(miss => console.log(`  ${miss}`))
     throw new Error(`Ignore list contains CVE IDs that were not returned in the findings result set. They may be invalid or no longer be current vulnerabilities.`)
   }
 

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ const countIgnoredFindings = (ignoredFindings) =>
     (counts, finding) => {
       const updatedCount = { ...counts }
       const severity = finding.severity.toLowerCase()
-      updatedCount[severity] = counts[severity] + 1
+      updatedCount[severity]++
       updatedCount.total++
       return updatedCount
     },

--- a/index.js
+++ b/index.js
@@ -63,13 +63,22 @@ const getCount = (severity, counts) =>
 
 /**
  * Build an array with CVE IDs to ignore in the counts.
- * @param {string | string[]} list - Comma separated list or array of CVE IDs.
+ * @param {string | string[]} list - Comma-separated list, string with newlines or array of CVE IDs.
  * @returns {string[]} Array of CVE IDs
  */
 const parseIgnoreList = (list) => {
-  if (Array.isArray(list)) return list
+  if (Array.isArray(list)) return list // when GitHub Actions allow arrays to be passed in.
   if (!list) return []
-  return list.split(',').map((d) => d.trim())
+
+  const ignoreList =
+    list
+      .trim() // remove trailing newlines if any
+      .replace(/\n/g, ',') // replace newlines with commas, if any
+      .split(',') // build the array
+      .map((i) => i.trim()) // ensure each item doesn't contain any white-space
+      .filter(Boolean) // remove empty items
+
+  return ignoreList
 }
 
 const main = async () => {

--- a/index.js
+++ b/index.js
@@ -10,8 +10,6 @@ const AWS = require('aws-sdk')
  *  informational: number,
  *  undefined: number,
  *  total: number }} IgnoredCounts
- *
- * @typedef {{ severity: string }} ImageScanFinding https://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_ImageScanFinding.html
  */
 
 /**
@@ -37,7 +35,7 @@ const getFindings = async (ECR, repository, tag, useMaxResults = false) => {
 
 /**
  * Tally findings by severity.
- * @param {ImageScanFinding[]} ignoredFindings
+ * @param {AWS.ECR.ImageScanFinding[]} ignoredFindings
  * @returns {IgnoredCounts} counts
  */
 const countIgnoredFindings = (ignoredFindings) =>
@@ -140,9 +138,7 @@ const main = async () => {
   }
 
   const findingsList = findings.imageScanFindings.findings
-  const ignoredFindings = findingsList.filter(({ name }) =>
-    ignoreList.includes(name)
-  )
+  const ignoredFindings = findingsList.filter(({ name }) => ignoreList.includes(name))
 
   if (ignoreList.length !== ignoredFindings.length) {
     throw new Error(`Ignore list contains CVE IDs that were not returned in the findings result set. They may be invalid or no longer be current vulnerabilities.`)

--- a/index.js
+++ b/index.js
@@ -1,11 +1,25 @@
 const core = require('@actions/core')
 const AWS = require('aws-sdk')
 
-const getFindings = async (ECR, repository, tag) => {
+/**
+ * @typedef {{
+ *  critical: number,
+ *  high: number,
+ *  medium: number,
+ *  low: number,
+ *  informational: number,
+ *  undefined: number,
+ *  total: number }} IgnoredCounts
+ *
+ * @typedef {{ severity: string }} ImageScanFinding https://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_ImageScanFinding.html
+ */
+
+const getFindings = async (ECR, repository, tag, useMaxResults = false) => {
   return ECR.describeImageScanFindings({
     imageId: {
       imageTag: tag
     },
+    maxResults: useMaxResults ? 1000 : undefined, // Valid range: 1-1000, default: 100
     repositoryName: repository
   }).promise().catch(
     (err) => {
@@ -14,11 +28,49 @@ const getFindings = async (ECR, repository, tag) => {
     })
 }
 
+/**
+ * Tally findings by severity.
+ * @param {ImageScanFinding[]} ignoredFindings
+ * @returns {IgnoredCounts} counts
+ */
+const countIgnoredFindings = (ignoredFindings) =>
+  ignoredFindings.reduce(
+    (counts, finding) => {
+      const updatedCount = { ...counts }
+      updatedCount[finding.severity] = counts[finding.severity] + 1
+      updatedCount.total++
+      return updatedCount
+    },
+    { critical: 0, high: 0, medium: 0, low: 0, informational: 0, undefined: 0, total: 0 }
+  )
+
+/**
+ * Returns display text for a severity level.
+ * @param {string} severity
+ * @param {IgnoredCounts} counts
+ * @returns {string}
+ */
+const getCount = (severity, counts) =>
+  counts[severity] ? `(${counts[severity]} ignored)` : ''
+
+/**
+ * Build an array with CVE IDs to ignore in the counts.
+ * @param {string | string[]} list - Comma separated list or array of CVE IDs.
+ * @returns {string[]} Array of CVE IDs
+ */
+const parseIgnoreList = (list) => {
+  if (Array.isArray(list)) return list
+  if (!list) return []
+  return list.split(',').map((d) => d.trim())
+}
+
 const main = async () => {
   core.debug('Entering main')
   const repository = core.getInput('repository', { required: true })
   const tag = core.getInput('tag', { required: true })
   const failThreshold = core.getInput('fail_threshold') || 'high'
+  const ignoreList = parseIgnoreList(core.getInput('ignore_list'))
+
   if (
     failThreshold !== 'critical' &&
     failThreshold !== 'high' &&
@@ -28,12 +80,12 @@ const main = async () => {
   ) {
     throw new Error('fail_threshold input value is invalid')
   }
-  core.debug(`Repository:${repository}, Tag:${tag}`)
+  core.debug(`Repository:${repository}, Tag:${tag}, Ignore list:${ignoreList}`)
   const ECR = new AWS.ECR()
 
   core.debug('Checking for existing findings')
   let status = null
-  let findings = await getFindings(ECR, repository, tag)
+  let findings = await getFindings(ECR, repository, tag, !!ignoreList.length)
   if (findings) {
     status = findings.imageScanStatus.status
     console.log(`A scan for this image was already requested, the scan's status is ${status}`)
@@ -70,6 +122,16 @@ const main = async () => {
     throw new Error(`Unhandled scan status "${status}". API response: ${JSON.stringify(findings)}`)
   }
 
+  const findingsList = findings.imageScanFindings.findings
+  const ignoredFindings = findingsList.filter(({ name }) =>
+    ignoreList.includes(name)
+  )
+
+  if (ignoreList.length !== ignoredFindings.length) {
+    throw new Error(`Ignore list contains CVE IDs that were not returned in the findings result set. They may be invalid or no longer be current vulnerabilities.`)
+  }
+
+  const ignoredCounts = countIgnoredFindings(ignoredFindings)
   const counts = findings.imageScanFindings.findingSeverityCounts
   const critical = counts.CRITICAL || 0
   const high = counts.HIGH || 0
@@ -77,6 +139,7 @@ const main = async () => {
   const low = counts.LOW || 0
   const informational = counts.INFORMATIONAL || 0
   const indeterminate = counts.UNDEFINED || 0
+  const ignored = ignoreList.length
   const total = critical + high + medium + low + informational + indeterminate
   core.setOutput('critical', critical.toString())
   core.setOutput('high', high.toString())
@@ -84,23 +147,24 @@ const main = async () => {
   core.setOutput('low', low.toString())
   core.setOutput('informational', informational.toString())
   core.setOutput('undefined', indeterminate.toString())
+  core.setOutput('ignored', ignored.toString())
   core.setOutput('total', total.toString())
   console.log('Vulnerabilities found:')
-  console.log(`${critical.toString().padStart(3, ' ')} Critical`)
-  console.log(`${high.toString().padStart(3, ' ')} High`)
-  console.log(`${medium.toString().padStart(3, ' ')} Medium`)
-  console.log(`${low.toString().padStart(3, ' ')} Low`)
-  console.log(`${informational.toString().padStart(3, ' ')} Informational`)
+  console.log(`${critical.toString().padStart(3, ' ')} Critical ${getCount(  'CRITICAL',  ignoredCounts)}`)
+  console.log(`${high.toString().padStart(3, ' ')} High ${getCount(  'HIGH',  ignoredCounts)}`)
+  console.log(`${medium.toString().padStart(3, ' ')} Medium ${getCount(  'MEDIUM',  ignoredCounts)}`)
+  console.log(`${low.toString().padStart(3, ' ')} Low ${getCount('LOW', ignoredCounts)}`)
+  console.log(`${informational.toString().padStart(3, ' ')} Informational ${getCount(  'INFORMATIONAL',  ignoredCounts)}`)
   console.log(`${indeterminate.toString().padStart(3, ' ')} Undefined`)
   console.log('=================')
-  console.log(`${total.toString().padStart(3, ' ')} Total`)
+  console.log(`${total.toString().padStart(3, ' ')} Total ${getCount(  'TOTAL',  ignoredCounts)}`)
 
   const numFailingVulns =
-    failThreshold === 'informational' ? total
-      : failThreshold === 'low' ? critical + high + medium + low
-        : failThreshold === 'medium' ? critical + high + medium
-          : failThreshold === 'high' ? critical + high
-            : /* failThreshold === 'critical' ? */ critical
+    failThreshold === 'informational' ? total - ignoredCounts.INFORMATIONAL
+      : failThreshold === 'low' ? critical + high + medium + low - ignoredCounts.LOW
+        : failThreshold === 'medium' ? critical + high + medium - ignoredCounts.MEDIUM
+          : failThreshold === 'high' ? critical + high - ignoredCounts.HIGH
+            : /* failThreshold === 'critical' ? */ critical - ignoredCounts.CRITICAL
 
   if (numFailingVulns > 0) {
     throw new Error(`Detected ${numFailingVulns} vulnerabilities with severity >= ${failThreshold} (the currently configured fail_threshold).`)


### PR DESCRIPTION
# Add "Ignore List" feature

I decided to go with "Ignore List" instead of "Allow List" to highlight the fact that **the user is making a conscious choice to _ignore_ certain CVEs**.

- Add `ignore_list` input to action
- Add `ignored` key to output
- Allow space & comma-separated list or multi-line list of CVE IDs
- Add ignore counts to summary
- Subtract ignored CVEs from vulnerability counts & check
- Errors if items on ignore list are not present in the findings. ⚠️ Caveat: [Maximum findings limited to 1000](https://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_DescribeImageScanFindings.html#API_DescribeImageScanFindings_RequestSyntax).
- Shows list of missed ignores (ignored CVEs not found in the scan report)
- Add JSDoc comments for better DX
- Update README

## Example

### Happy path

Input:

```bash
$ INPUT_REPOSITORY=develop INPUT_TAG=latest INPUT_IGNORE_LIST=CVE-2019-1349 INPUT_FAIL_THRESHOLD=critical node index.js
```

Output:

```bash
::debug::Entering main
::debug::Repository:develop, Tag:latest, Ignore list:CVE-2019-1349
::debug::Checking for existing findings
A scan for this image was already requested, the scan's status is COMPLETE
::set-output name=critical::16
::set-output name=high::76
::set-output name=medium::305
::set-output name=low::283
::set-output name=informational::354
::set-output name=undefined::18
::set-output name=ignored::1
::set-output name=total::1052
Vulnerabilities found:
 16 Critical (1 ignored)
 76 High 
305 Medium 
283 Low 
354 Informational 
 18 Undefined
=================
1052 Total (1 ignored)
::error::Detected 15 vulnerabilities with severity >= critical (the currently configured fail_threshold).
```

### Unhappy path

Input:

```bash
$ INPUT_REPOSITORY=develop INPUT_TAG=latest INPUT_IGNORE_LIST=CVE-2019-13493 INPUT_FAIL_THRESHOLD=critical node index.js
```

Output:

```bash
::debug::Entering main
::debug::Repository:develop, Tag:latest, Ignore list:CVE-2019-13493
::debug::Checking for existing findings
A scan for this image was already requested, the scan's status is COMPLETE
::error::Ignore list contains CVE IDs that were not returned in the findings result set. They may be invalid or no longer be current vulnerabilities.
```

Closes #7