### PR TITLE
switch to using dummy CVE IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ jobs:
           tag: ${{ steps.docker-build.outputs.tag }}
           # fail_threshold: medium
           # ignore_list: |
-          #   CVE-2020-1234
-          #   CVE-2020-5678
+          #   CVE-2014-7654321
+          #   CVE-2014-456132
       # Access scan results in later steps
       - run: echo "${{ steps.docker-scan.outputs.total }} total vulnerabilities."
 ```


### PR DESCRIPTION
using example CVEs from the syntax change as listed here: https://cve.mitre.org/cve/identifiers/syntaxchange.html   avoids what may be a valid CVE assignment for 2020-5678 and is valid for 2020-1234, which can get caught in various threat intel searches that look for valid IDs.