### PR TITLE
errorMissedIgnores parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ As of version `3.0.0`, only enhanced scanning is supported. Basic scanning suppo
 | repository | :white_check_mark:  | ECR repository, eg myorg/myimage |
 | tag    | :white_check_mark: | Image tag to scan |
 | fail_threshold | | Fail if any vulnerabilities equal to or over this severity level are detected. Valid values: `critical`, `high`, `medium`, `low`, `informational`. Default value is `high`. |
+| missedCVELogLevel | | Set the log level for missed CVEs. Valid values: `error`, `warn`. Determines whether a core.error or a core.warning is raised when the ignore list contains CVE IDs that were not found in the scan results. Default value is error. |
 | ignore_list | | List of CVE IDs to ignore.<br/>:warning: **Note**: The `ignore_list` can either be a multi-line string (like the example below) or a list (separated using commas or spaces) containing CVE IDs to be ignored. |
 
 ## Outputs

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     description: List of CVE IDs to ignore in the vulnerability findings.
   error_missed_ignores:
     description: >
-      Set to error if you want to raise an error when CVEs in the ignore list are not found. Set to warn to raise a warning, but prevent failure when CVEs in the ignore list are not found.
+      Set to "error" if you want to raise an error when CVEs in the ignore list are not found. Set to "warn" to raise a warning only, and prevent the workflow from failing when CVEs in the ignore list are not found.
     required: false
     default: error
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,11 @@ inputs:
     default: medium
   ignore_list:
     description: List of CVE IDs to ignore in the vulnerability findings.
+  error_missed_ignores:
+    description: >
+      Set to true if you want to raise an error when CVEs in the ignore list are not found.
+    required: false
+    default: true
 outputs:
   critical:
     description: Number of critical vulnerabilities detected.

--- a/action.yml
+++ b/action.yml
@@ -15,9 +15,9 @@ inputs:
     description: List of CVE IDs to ignore in the vulnerability findings.
   error_missed_ignores:
     description: >
-      Set to true if you want to raise an error when CVEs in the ignore list are not found.
+      Set to error if you want to raise an error when CVEs in the ignore list are not found. Set to warn to raise a warning, but prevent failure when CVEs in the ignore list are not found.
     required: false
-    default: true
+    default: error
 outputs:
   critical:
     description: Number of critical vulnerabilities detected.

--- a/index.js
+++ b/index.js
@@ -174,6 +174,7 @@ const main = async () => {
   const tag = core.getInput('tag', { required: true })
   const failThreshold = core.getInput('fail_threshold') || 'high'
   const ignoreList = parseIgnoreList(core.getInput('ignore_list'))
+  const errorMissedIgnores = core.getInput('error_missed_ignores') === 'false' ? false : true;
 
   const proxyUrl = process.env.HTTPS_PROXY || process.env.https_proxy
   if (proxyUrl !== undefined) {
@@ -240,7 +241,11 @@ const main = async () => {
     const missedIgnores = ignoreList.filter(vulnerabilityId => !ignoredFindings.map(({ packageVulnerabilityDetails }) => packageVulnerabilityDetails.vulnerabilityId).includes(vulnerabilityId));
     console.log('The following CVEs were not found in the result set:');
     missedIgnores.forEach(miss => console.log(`  ${miss}`));
-    throw new Error(`Ignore list contains CVE IDs that were not returned in the findings result set. They may be invalid or no longer be current vulnerabilities.`);
+    if (errorMissedIgnores) {
+      throw new Error(`Ignore list contains CVE IDs that were not returned in the findings result set. They may be invalid or no longer be current vulnerabilities.`);
+    } else {
+      core.warning(`Ignore list contains CVE IDs that were not returned in the findings result set. They may be invalid or no longer be current vulnerabilities.`);
+    }  
   }
 
   const ignoredCounts = countIgnoredFindings(ignoredFindings)

--- a/index.js
+++ b/index.js
@@ -174,7 +174,15 @@ const main = async () => {
   const tag = core.getInput('tag', { required: true })
   const failThreshold = core.getInput('fail_threshold') || 'high'
   const ignoreList = parseIgnoreList(core.getInput('ignore_list'))
-  const errorMissedIgnores = core.getInput('error_missed_ignores') === 'false' ? false : true;
+  const missedCVELogLevel = core.getInput('missedCVELogLevel') || 'error'
+
+  //Validate missedCVELogLevel
+  if (
+    missedCVELogLevel !== 'warn' &&
+    missedCVELogLevel !== 'error'
+  ) {
+    throw new Error('missedCVELogLevel input value is invalid. It must be either "warn" or "error".')
+  }
 
   const proxyUrl = process.env.HTTPS_PROXY || process.env.https_proxy
   if (proxyUrl !== undefined) {
@@ -241,7 +249,7 @@ const main = async () => {
     const missedIgnores = ignoreList.filter(vulnerabilityId => !ignoredFindings.map(({ packageVulnerabilityDetails }) => packageVulnerabilityDetails.vulnerabilityId).includes(vulnerabilityId));
     console.log('The following CVEs were not found in the result set:');
     missedIgnores.forEach(miss => console.log(`  ${miss}`));
-    if (errorMissedIgnores) {
+    if (missedCVELogLevel === 'error') {
       throw new Error(`Ignore list contains CVE IDs that were not returned in the findings result set. They may be invalid or no longer be current vulnerabilities.`);
     } else {
       core.warning(`Ignore list contains CVE IDs that were not returned in the findings result set. They may be invalid or no longer be current vulnerabilities.`);


### PR DESCRIPTION
Introduces parameter to only raise a warning when CVE's defined in the ignore list are not found in scan results. Currently this will result in an error.

This parameter defaults to true as to remain a non-impactful change.