### PR TITLE
fix: Unhandled scan status "PENDING"

### DIFF
--- a/index.js
+++ b/index.js
@@ -219,11 +219,11 @@ const main = async () => {
       },
       repositoryName: repository
     }).promise()
-    status = 'IN_PROGRESS'
+    status = 'PENDING'
   }
 
   let firstPoll = true
-  while (status === 'IN_PROGRESS') {
+  while (status === 'PENDING' || status === 'IN_PROGRESS') {
     if (!firstPoll) {
       await new Promise((resolve) => {
         setTimeout(resolve, 5000)


### PR DESCRIPTION
The following error often occurs in our CI environment:

> Error: Unhandled scan status "PENDING". API response: {"registryId":"222222222222","repositoryName":"dummy","imageId":{"imageDigest":"sha256:08eec9208c975baa1df884a1009b38426b1a44e90048d7ae82f59ba268767c36","imageTag":"08eec9208c975baa1df884a1009b38426b1a44e90048d7ae82f59ba268767c36"},"imageScanStatus":{"status":"PENDING","description":"Pending start of the image scan."},"imageScanFindings":{"findings":[],"enhancedFindings":[]}}

And here is the AWS documentation:

https://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_ImageScanStatus.html
> Valid Values: `IN_PROGRESS` | `COMPLETE | FAILED` | `UNSUPPORTED_IMAGE` | `ACTIVE` | `PENDING` | `SCAN_ELIGIBILITY_EXPIRED` | `FINDINGS_UNAVAILABLE`